### PR TITLE
Release v0.20.0 (to dev)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## vNext
 ...
 
+## 0.20.0
+- Synced codebase with the Polkadot-JS App master branch.
+- Fixed bugs related to merging the new version.
+- Replaced the node image in the workflow from version 14 to the latest LTS version.
+
 ## 0.19.0
 - Hid Files (IPFS) page
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "url": "https://github.com/polkadot-js/apps.git"
   },
   "sideEffects": false,
-  "version": "0.19.0-cere",
+  "version": "0.20.0-cere",
   "versions": {
-    "git": "0.19.0-cere",
-    "npm": "0.19.0-cere"
+    "git": "0.20.0-cere",
+    "npm": "0.20.0-cere"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Release **v0.20.0** (to dev)
- Synced codebase with the Polkadot-JS App master branch.
- Fixed bugs related to merging the new version.
- Replaced the node image in the workflow from version 14 to the latest LTS version.
