### PR TITLE
Add auto generation of Cere Network type bundle.

### DIFF
--- a/packages/apps-config/src/api/chain/cere.ts
+++ b/packages/apps-config/src/api/chain/cere.ts
@@ -1,28 +1,82 @@
-// Copyright 2017-2021 @polkadot/apps-config authors & contributors
+// Copyright 2017-2023 @polkadot/apps-config authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// structs need to be in order
-/* eslint-disable sort-keys */
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
 
-export default {
-  ChainId: 'u8',
-  DepositNonce: 'u64',
-  ResourceId: '[u8; 32]',
-  ProposalStatus: {
-    _enum: ['Initiated', 'Approved', 'Rejected']
-  },
-  ProposalVotes: {
-    votes_for: 'Vec<AccountId>',
-    votes_against: 'Vec<AccountId>',
-    status: 'ProposalStatus',
-    expiry: 'BlockNumber'
-  },
-  TokenId: 'u256',
-  Erc721Token: {
-    id: 'TokenId',
-    metadata: 'Vec<u8>'
-  },
-  Address: 'MultiAddress',
-  LookupSource: 'MultiAddress',
-  AccountInfo: 'AccountInfoWithDualRefCount'
+const definitions: OverrideBundleDefinition = {
+  types: [
+    {
+      minmax: [
+        266,
+        281
+      ],
+      types: {
+        ChainId: 'u8',
+        DepositNonce: 'u64',
+        ResourceId: '[u8; 32]',
+        ProposalStatus: {
+          _enum: [
+            'Initiated',
+            'Approved',
+            'Rejected'
+          ]
+        },
+        ProposalVotes: {
+          votes_for: 'Vec<AccountId>',
+          votes_against: 'Vec<AccountId>',
+          status: 'ProposalStatus',
+          expiry: 'BlockNumber'
+        },
+        TokenId: 'u256',
+        Erc721Token: {
+          id: 'TokenId',
+          metadata: 'Vec<u8>'
+        },
+        Address: 'IndicesLookupSource',
+        LookupSource: 'IndicesLookupSource',
+        AccountInfo: 'AccountInfoWithDualRefCount',
+        ValidatorPrefs: {
+          commission: 'Compact<Perbill>'
+        }
+      }
+    },
+    {
+      minmax: [
+        282,
+        294
+      ],
+      types: {
+        ChainId: 'u8',
+        DepositNonce: 'u64',
+        ResourceId: '[u8; 32]',
+        ProposalStatus: {
+          _enum: [
+            'Initiated',
+            'Approved',
+            'Rejected'
+          ]
+        },
+        ProposalVotes: {
+          votes_for: 'Vec<AccountId>',
+          votes_against: 'Vec<AccountId>',
+          status: 'ProposalStatus',
+          expiry: 'BlockNumber'
+        },
+        TokenId: 'u256',
+        Erc721Token: {
+          id: 'TokenId',
+          metadata: 'Vec<u8>'
+        },
+        Address: 'MultiAddress',
+        LookupSource: 'MultiAddress',
+        AccountInfo: 'AccountInfoWithDualRefCount'
+      }
+    },
+    {
+      minmax: [295, null],
+      types: {}
+    }
+  ]
 };
+
+export default definitions;

--- a/packages/apps-config/src/api/chain/index.ts
+++ b/packages/apps-config/src/api/chain/index.ts
@@ -1,0 +1,13 @@
+// Copyright 2017-2023 @polkadot/apps-config authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OverrideBundleDefinition } from '@polkadot/types/types';
+
+import cere from './cere.js';
+
+// NOTE: The mapping is done from chain name in system.chain
+const chain: Record<string, OverrideBundleDefinition> = {
+  'Cere Mainnet Beta': cere
+};
+
+export default chain;

--- a/packages/apps-config/src/api/typesBundle.spec.ts
+++ b/packages/apps-config/src/api/typesBundle.spec.ts
@@ -5,11 +5,16 @@ import fs from 'fs';
 
 import { objectSpread } from '@polkadot/util';
 
+import chain from './chain/index.js';
 import spec from './spec';
 
 it('generates the typesBundle', (): void => {
   const specEntries = Object.entries(spec);
-  const typesBundle: { spec: Record<string, unknown> } = { spec: {} };
+  const chainEntries = Object.entries(chain);
+  const typesBundle: {
+    chain: Record<string, unknown>
+    spec: Record<string, unknown>
+  } = { chain: {}, spec: {} };
 
   specEntries.forEach(([k, v]): void => {
     const value = objectSpread<{ derives: unknown }>({}, v);
@@ -17,6 +22,14 @@ it('generates the typesBundle', (): void => {
     delete value.derives;
 
     typesBundle.spec[k] = value;
+  });
+
+  chainEntries.forEach(([k, v]): void => {
+    const value = objectSpread<{ derives: unknown }>({}, v);
+
+    delete value.derives;
+
+    typesBundle.chain[k] = value;
   });
 
   fs.writeFileSync('packages/apps-config/src/api/typesBundle.ts', `// Copyright 2017-2022 @polkadot/apps-config authors & contributors

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -81,11 +81,14 @@ export const typesBundle = {
           }
         },
         {
-          "minmax": [295, null],
+          "minmax": [
+            295,
+            null
+          ],
           "types": {}
         }
       ]
-    },
+    }
   },
   "spec": {
     "Crab": {


### PR DESCRIPTION
Initially, I modified the file that generates automatically. I correctly integrated the Cere Network Type bundle and added the generation of chains that will be supported in future versions of Polkadot JS Apps. Now, everything is functioning as intended.